### PR TITLE
Adjust DSA example formatting

### DIFF
--- a/vadovas/spinta.rst
+++ b/vadovas/spinta.rst
@@ -818,14 +818,14 @@ Tai sugeneruotas :term:`DSA` atrodys taip:
 
 .. code-block:: sh
 
-id | d | r | b | m | property   | type                    | ref | source       | prepare | level | access | uri | title | description
-   | dataset                    |                         |     |              |         |       |        |     |       |
-   |   | resource               | xml                     |     | data.xml     |         |       |        |     |       |
-   |                            |                         |     |              |         |       |        |     |       |
-   |   |   |   | City           |                         |     | /cities/city |         |       |        |     |       |
-   |   |   |   |   | code       | string required unique  |     | @code        |         |       |        |     |       |
-   |   |   |   |   | name       | string required unique  |     | name         |         |       |        |     |       |
-   |   |   |   |   | population | integer required unique |     | population   |         |       |        |     |       |
+    id | d | r | b | m | property   | type                    | ref | source       | prepare | level | access | uri | title | description
+       | dataset                    |                         |     |              |         |       |        |     |       |
+       |   | resource               | xml                     |     | data.xml     |         |       |        |     |       |
+       |                            |                         |     |              |         |       |        |     |       |
+       |   |   |   | City           |                         |     | /cities/city |         |       |        |     |       |
+       |   |   |   |   | code       | string required unique  |     | @code        |         |       |        |     |       |
+       |   |   |   |   | name       | string required unique  |     | name         |         |       |        |     |       |
+       |   |   |   |   | population | integer required unique |     | population   |         |       |        |     |       |
 
 
 XSD schema


### PR DESCRIPTION
Adjust incorrectly formatted DSA example:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/39c2987f-0d90-49ea-a0c1-4071119cc7f6" />

#### Source:
- https://atviriduomenys.readthedocs.io/spinta.html#xsd-schema